### PR TITLE
Alterações na tabela clientes

### DIFF
--- a/application/database/migrations/20240802172733_add_nomefantasia_to_clientes_table.php
+++ b/application/database/migrations/20240802172733_add_nomefantasia_to_clientes_table.php
@@ -1,0 +1,25 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_nomefantasia_to_clientes_table extends CI_Migration {
+
+    public function up()
+    {
+        // Adiciona o campo nome fantasia
+        $this->dbforge->add_column('clientes', array(
+            'nomeFantasia' => array(
+                'type' => 'VARCHAR',
+                'constraint' => '100',
+                'null' => true,
+            ),
+        ));
+
+    }
+
+    public function down()
+    {
+        // Remove o campo nome fantasia
+        $this->dbforge->drop_column('clientes', 'nomeFantasia');
+
+    }
+}

--- a/application/database/migrations/20240802172733_alter_length_fields_at_clientes_table.php
+++ b/application/database/migrations/20240802172733_alter_length_fields_at_clientes_table.php
@@ -1,0 +1,25 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_alter_length_fields_at_clientes_table extends CI_Migration {
+
+    public function up()
+    {
+        // Altera o comprimento do campo rua
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `rua` `rua` VARCHAR(100) NULL DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `bairro` `bairro` VARCHAR(100) DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `cidade` `cidade` VARCHAR(100) DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `contato` `contato` VARCHAR(100) DEFAULT NULL ;');
+
+    }
+
+    public function down()
+    {
+        // Remove as alterações nos comprimentos dos campos
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `rua` `rua` VARCHAR(70) NULL DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `bairro` `bairro` VARCHAR(45) DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `cidade` `cidade` VARCHAR(45) DEFAULT NULL ;');
+        $this->db->query('ALTER TABLE `mapos`.`clientes` CHANGE COLUMN `contato` `contato` VARCHAR(45) DEFAULT NULL ;');
+
+    }
+}


### PR DESCRIPTION
Para facilitar a identificação de clientes empresariais, é necessário incluir o campo _nome fantasia_ na tabela clientes.
O comprimento dos campos _rua_, _bairro_ e _cidade_ aumentados de 45 caracteres para 100.